### PR TITLE
fix: update openjdk container reference

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,7 +7,7 @@ function exec() {
         -v ~/Android/Sdk/:/Android/Sdk/ \
         -e ANDROID_HOME=/Android/Sdk \
         -w /app \
-          android-openjdk:24 bash 
+          openjdk:24 bash 
 
 }
 


### PR DESCRIPTION
Reference mismatch as the container name "android-openjdk" doesnt exist, this change should fix the issue